### PR TITLE
Removed monkey patching http

### DIFF
--- a/lib/framework/connect.js
+++ b/lib/framework/connect.js
@@ -3,11 +3,8 @@
  */
 /* eslint-disable camelcase, no-proto, no-shadow */
 
-const http = require('http');
 const initialize = require('../middleware/initialize');
 const authenticate = require('../middleware/authenticate');
-const IncomingMessageExt = require('../http/request');
-
 /**
  * Framework support for Connect/Express.
  *
@@ -22,22 +19,8 @@ const IncomingMessageExt = require('../http/request');
 
 // eslint-disable-next-line no-multi-assign, func-names
 exports = module.exports = function () {
-  // HTTP extensions.
-  exports.__monkeypatchNode();
-
   return {
     initialize,
     authenticate,
   };
-};
-
-exports.__monkeypatchNode = function __monkeypatchNode() {
-  http.IncomingMessage.prototype.logIn = IncomingMessageExt.logIn;
-  http.IncomingMessage.prototype.login = http.IncomingMessage.prototype.logIn;
-
-  http.IncomingMessage.prototype.logOut = IncomingMessageExt.logOut;
-  http.IncomingMessage.prototype.logout = http.IncomingMessage.prototype.logOut;
-
-  http.IncomingMessage.prototype.isAuthenticated = IncomingMessageExt.isAuthenticated;
-  http.IncomingMessage.prototype.isUnauthenticated = IncomingMessageExt.isUnauthenticated;
 };

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -4,10 +4,13 @@
 
 // var http = require('http')
 //  , req = http.IncomingMessage.prototype;
+const http = require('http');
+
+const req = http.IncomingMessage.prototype;
 
 /* eslint-disable no-multi-assign, camelcase, no-proto, no-shadow */
 
-const req = exports = module.exports = {};
+// const req = exports = module.exports = {};
 
 /**
  * Initiate a login session for `user`.
@@ -104,3 +107,5 @@ req.isAuthenticated = function isAuthenticated() {
 req.isUnauthenticated = function isUnauthenticated() {
   return !this.isAuthenticated();
 };
+
+module.exports = req;

--- a/test/http/request.test.js
+++ b/test/http/request.test.js
@@ -6,7 +6,7 @@
 const http = require('http');
 const Passport = require('../..').Passport;
 
-require('../../lib/framework/connect').__monkeypatchNode();
+require('../../lib/framework/connect')();
 
 
 describe('http.ServerRequest', () => {


### PR DESCRIPTION
Removed monkey patching, and merely extended the http module.
- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
