### PR TITLE
Delay connect require until authenticate called

### DIFF
--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -7,7 +7,6 @@
 const http = require('http');
 const IncomingMessageExt = require('../http/request');
 const AuthenticationError = require('../errors/authenticationerror');
-const connect = require('../framework/connect');
 
 
 /**
@@ -98,7 +97,8 @@ module.exports = function authenticate(passport, name, options, callback) {
   return function authenticate(req, res, next) {
     if (http.IncomingMessage.prototype.logIn
         && http.IncomingMessage.prototype.logIn !== IncomingMessageExt.logIn) {
-      connect.__monkeypatchNode();
+      // eslint-disable-next-line
+      require('../framework/connect').__monkeypatchNode();
     }
 
 


### PR DESCRIPTION
In d53ff7df95a11e7241e35dcf7d139a03fc74d5d5  (https://github.com/passport-next/passport/commit/d53ff7df95a11e7241e35dcf7d139a03fc74d5d5#diff-3d4f4aac823ef6b0561ea61cb312b2c7R10), it moves `const connect = require('../framework/connect')` to the top. But it brings up the following error for me because there's a circular require in both `authentication.js` and `connect.js`.

```
TypeError: connect.__monkeypatchNode is not a function
    at authenticate (node_modules/@passport-next/passport/lib/middleware/authenticate.js:101:15)
    at Layer.handle [as handle_request] (node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (node_modules/express/lib/router/index.js:317:13)
    at node_modules/express/lib/router/index.js:284:7
```

This fix reverts part of commit d53ff7df95a11e7241e35dcf7d139a03fc74d5d5, and moves `require connect` to original position.

<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/passport-next/passport/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ npm run-script lint`) executes successfully.
