### PR TITLE
feat: avoid Express dependency by redirecting for user when res.redirect is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,63 @@ This changelog follows Semantic Versioning https://semver.org/
 
 ### Major
 
+- chore: Require Node.js `^22.22.2 || >=24.15.0`.
+- refactor: Publish native ESM only and define the package through `exports`.
+  CommonJS `require()` is no longer supported. The default ESM export remains
+  the Passport singleton; `Passport`, `Authenticator`, `Strategy`,
+  `EnhancedStrategy`, and `strategies` are available as named exports.
+- feat: Publish generated TypeScript declarations through the package export;
+  fixes #5.
+- refactor: Registered serializers and deserializers are now invoked as
+  `(request, value, done)`, and auth-info transforms as
+  `(request, info, done)`. The previous function-arity dispatch for
+  `(value, done)` callbacks and one-argument synchronous transforms has been
+  removed. Promise and synchronous-return handlers must also use the
+  request-first signature.
+- refactor: `serializeUser`, `deserializeUser`, and `transformAuthInfo` now
+  return Promises when executing their registered handler chains.
+  Callback-style handlers remain supported, but must call `done(...)` without
+  returning it because non-`undefined` return values and Promises are treated
+  as handler results.
+- refactor: `req.logIn` and `req.login` no longer throw merely because a
+  callback was omitted; they always return a Promise and reject it on failure
+  when no callback handles the error.
 
 ### Minor
 
-- feat: avoid Express dependency by redirecting for user when res.redirect is not available
+- feat: Registered serializers, deserializers, and auth-info transforms may
+  return a synchronous result or a Promise instead of calling `done`.
+- feat: Thrown or rejected `Error('pass')` values advance to the next
+  serializer, deserializer, or auth-info transform, matching `done('pass')`.
+- feat: `req.logIn`/`login`, `SessionManager#logIn`, session restoration, and
+  authentication middleware success handling support async/await while
+  retaining their callback forms.
 
 ### Patch
 
+- security: Reject prototype-related `userProperty` keys and Passport-owned
+  request fields or methods, including `__proto__`, `_passport`, and `logIn`.
+  Invalid values passed to `initialize({ userProperty })` now throw a
+  `TypeError`, preventing request prototype manipulation or overwriting of
+  Passport request state and behavior.
+- feat: Prefer `res.redirect` when supplied by the framework, and otherwise
+  redirect with the native Node response API. Native redirects set status 302,
+  `Location`, and a zero content length; session-backed redirects still wait
+  for `session.save()`; fixes #24.
+- fix: Avoid an error when authentication fails without a recorded failure and
+  an application callback handles the result.
+- fix: Guard access to the request's Passport `instance` when middleware has
+  not initialized it.
+- docs: Add async/await serialization examples and update session examples to
+  use `express-session` without `cookieParser`.
+- test: Add synchronous and Promise handler coverage, callback-free login and
+  session restoration coverage, and Connect/Express redirect coverage.
+- chore: Add declaration builds and `attw` package validation, migrate coverage
+  from `nyc` to `c8`, adopt ESLint flat config, and move the lockfile/workspace
+  to pnpm.
+- chore: Add JSDoc build/open scripts and a `test-one` script for focused tests.
+- chore: Update development dependencies and remove obsolete ESLint peer
+  dependencies.
 
 ## 3.1.0 (2019-12-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,26 @@ This changelog follows Semantic Versioning https://semver.org/
 
 # UNRELEASED
 
-## 3.1.0
+## 4.0.0 (2026-08-14)
+
+### Major
+
+
+### Minor
+
+- feat: avoid Express dependency by redirecting for user when res.redirect is not available
+
+### Patch
+
+
+## 3.1.0 (2019-12-11)
 
 ### Minor
 
 * Feature: Pass instantiated strategy to authenticate. @rwky @jaredhanson @ayZagen
 * Updated npm deps @rwky
 
-## 3.0.1
+## 3.0.1 (2019-09-10)
 
 ### Patch
 

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -55,7 +55,7 @@ import AuthenticationError from '../errors/authenticationerror.js';
 
 /**
  * @typedef {import('@passport-next/http-types').ConnectResponse & {
- *   redirect: (url: string) => void
+ *   redirect?: (url: string) => void
  * }} AuthenticateResponse
  */
 
@@ -152,10 +152,9 @@ import AuthenticationError from '../errors/authenticationerror.js';
  * responsibility to log-in the user, establish a session, and otherwise perform
  * the desired operations.
  *
- * Note that its redirecting behavior relies on `res.redirect` (available in
- * Express but not Connect).
+ * Redirects use `res.redirect` when available, with a native Node response as a
+ * fallback for framework-neutral Connect middleware.
  * @example
- *
  *     passport.authenticate('local', { successRedirect: '/', failureRedirect: '/login' });
  *
  *     passport.authenticate('basic', { session: false });
@@ -208,14 +207,24 @@ function authenticate(passport, name, options, callback) {
     /**
      * @param {string} url
      * @returns {void}
-     * @see https://expressjs.com/en/api.html#res.redirect
      */
     function redirect(url) {
+      const complete = () => {
+        if (response.redirect) {
+          response.redirect(url);
+          return;
+        }
+        response.statusCode = 302;
+        response.setHeader('Location', url);
+        response.setHeader('Content-Length', '0');
+        response.end();
+      };
+
       if (request.session && request.session.save && typeof request.session.save === 'function') {
-        request.session.save(() => response.redirect(url));
+        request.session.save(complete);
         return;
       }
-      response.redirect(url);
+      complete();
     }
 
     /**

--- a/test/middleware/authenticate.redirect.test.js
+++ b/test/middleware/authenticate.redirect.test.js
@@ -44,7 +44,7 @@ describe('middleware/authenticate', () => {
     });
   });
 
-  describe('redirect with session', () => {
+  describe('redirect with session using Connect response', () => {
     class Strategy extends EnhancedStrategy {
       authenticate() {
         const user = { id: '1', username: 'idurotola' };
@@ -59,17 +59,19 @@ describe('middleware/authenticate', () => {
     let request;
     /** @type {import('@passport-next/chai-connect-middleware').Response} */
     let response;
+    let sessionSaved = false;
     const authenticator = authenticate(passport, 'success', {
       successRedirect: 'https://www.example.com/idp'
     });
 
     before((done) => {
-      chai.connect.use('express', authenticator)
+      chai.connect.use(authenticator)
         .req((req) => {
           request = req;
 
           req.session = {};
           req.session.save = function save(done) {
+            sessionSaved = true;
             done();
           };
 
@@ -89,8 +91,72 @@ describe('middleware/authenticate', () => {
     });
 
     it('should redirect', () => {
+      expect(sessionSaved).to.be.true;
       expect(response.statusCode).to.equal(302);
       expect(response.getHeader('Location')).to.equal('https://www.example.com/idp');
+      expect(response.getHeader('Content-Length')).to.equal('0');
+    });
+  });
+
+  describe('failure redirect using Connect response', () => {
+    class Strategy extends EnhancedStrategy {
+      authenticate() {
+        this.fail();
+      }
+    }
+
+    const passport = new Passport();
+    passport.use('fail', new Strategy());
+
+    /** @type {import('@passport-next/chai-connect-middleware').Response} */
+    let response;
+
+    before((done) => {
+      chai.connect.use(authenticate(passport, 'fail', {
+        failureRedirect: 'https://www.example.com/login'
+      }))
+        .end((res) => {
+          response = res;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should redirect', () => {
+      expect(response.statusCode).to.equal(302);
+      expect(response.getHeader('Location')).to.equal('https://www.example.com/login');
+      expect(response.getHeader('Content-Length')).to.equal('0');
+    });
+  });
+
+  describe('failure redirect using Express response', () => {
+    class Strategy extends EnhancedStrategy {
+      authenticate() {
+        this.fail();
+      }
+    }
+
+    const passport = new Passport();
+    passport.use('fail', new Strategy());
+
+    /** @type {import('@passport-next/chai-connect-middleware').Response} */
+    let response;
+
+    before((done) => {
+      chai.connect.use('express', authenticate(passport, 'fail', {
+        failureRedirect: 'https://www.example.com/login'
+      }))
+        .end((res) => {
+          response = res;
+          done();
+        })
+        .dispatch();
+    });
+
+    it('should redirect using the framework response', () => {
+      expect(response.statusCode).to.equal(302);
+      expect(response.getHeader('Location')).to.equal('https://www.example.com/login');
+      expect(response.getHeader('Content-Length')).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
feat: avoid Express dependency by redirecting for user when res.redirect is not available; fixes #24

Also:
- docs: update CHANGES

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/passport-next/passport/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have updated the UNRELEASED section of the [CHANGELOG](https://github.com/passport-next/passport/blob/master/CHANGELOG.md).
- [x] I have added myself to the contributors section of package.json if I wish to be listed
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ npm test`) executes successfully.
- [x] The automated code linting (`$ npm run-script lint`) executes successfully.
